### PR TITLE
Add TUNGETPPA to get current PPA

### DIFF
--- a/if_tun.h
+++ b/if_tun.h
@@ -91,5 +91,6 @@ struct tundladdr {
 /* IOCTL defines */
 #define TUNNEWPPA	(('T'<<16) | 0x0001)
 #define TUNSETPPA	(('T'<<16) | 0x0002)
+#define TUNGETPPA	(('T'<<16) | 0x0003)
 
 #endif	/* _SYS_IF_TUN_H */

--- a/tun.c
+++ b/tun.c
@@ -458,6 +458,15 @@ static void tun_ioctl(queue_t *wq, mblk_t *mp)
   	DBG(CE_CONT,"tun: str %p attached to PPA %d \n", str, p);
         break;
 
+     case TUNGETPPA:
+	ppa = str->ppa;
+	if (str->ppa == NULL) {
+	   tuniocack(wq, mp, M_IOCNAK, 0, ENODEV);
+	   break;
+	}
+        tuniocack(wq, mp, M_IOCACK, ppa->id, 0);
+        break;
+
      case DLIOCRAW:          /* Raw M_DATA mode */
         str->flags |= TUN_RAW;
         tuniocack(wq, mp, M_IOCACK, 0, 0);


### PR DESCRIPTION
Add TUNGETPPA for symmetry and for processes that get a file descriptor to the tunnel device but not the name.